### PR TITLE
feat: add Claude Code web environment support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -266,8 +266,8 @@
             mdarocha.zsh.autoDirectenvAllow = true;
 
             home = {
-              username = "user";
-              homeDirectory = "/home/user";
+              username = "root";
+              homeDirectory = "/root";
 
               # required, otherwise the "nix" binary cannot be found in $PATH
               sessionVariablesExtra = ''

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+USER="${USER:-$(id -un)}"
+
 # Support running via curl | bash: if not executing from a file, clone the repo first
 if [[ ! -f "${BASH_SOURCE[0]:-}" ]]; then
     DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"


### PR DESCRIPTION
## Summary

- Adds a `claude` home-manager configuration targeting the Claude Code web container (runs as `root`/`/root`, no systemd, no llm-agents)
- Detects the environment via `CLAUDE_CODE_REMOTE=true` (set only in the remote web container, not local Claude Code instances)
- `install.sh` now supports `curl … | bash` by cloning the repo to `~/.dotfiles` and re-execing when not running from a file
- `install.sh` defines `USER` early via `id -un` to handle containers where it isn't exported
- Adds `mdarocha.zsh.autoDirectenvAllow` module option — enabled for `claude` and `codespace` — which runs `direnv allow` unconditionally at shell start if `.envrc` exists (trust is implied in ephemeral single-user containers)
- `claude` and `codespace` nix install path uses `--init none` + ACL workarounds + init.d nix-daemon (no systemd)

## Test plan

- [ ] `curl https://raw.githubusercontent.com/mdarocha/dotfiles/main/install.sh | bash` clones and runs correctly
- [ ] `CLAUDE_CODE_REMOTE=true` selects the `claude` configuration
- [ ] `nix flake check` passes (CI green)
- [ ] Home manager applies cleanly in the Claude Code web container as root
- [ ] `direnv allow` fires automatically on shell start when `.envrc` is present

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdw4shRJ4FqjNvSGopbVPy)_