### PR TITLE
fix: guard apt-get acl install behind availability check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,15 +33,19 @@ install_nix() {
 }
 
 install_nix_codespace_workarounds() {
-    # Fixes issue with "suspicous owner or permissions" error
+    # Fixes issue with "suspicious owner or permissions" error
     if ! command -v setfacl &> /dev/null; then
-        echo "🔨 Installing ACL..."
-        sudo apt-get update || true
-        sudo apt-get install -y --no-install-recommends acl
-        sudo rm -rf /var/lib/apt/lists/*
+        if command -v apt-get &> /dev/null; then
+            echo "🔨 Installing ACL..."
+            sudo apt-get update || true
+            sudo apt-get install -y --no-install-recommends acl
+            sudo rm -rf /var/lib/apt/lists/*
+        fi
     fi
 
-    sudo setfacl -k /tmp
+    if command -v setfacl &> /dev/null; then
+        sudo setfacl -k /tmp
+    fi
 }
 
 install_nix_daemon_initd_service() {


### PR DESCRIPTION
## Summary

- `install_nix_codespace_workarounds` is called for both `codespace` and `claude` environments, but `apt-get` may not be present in the claude container
- Guard the `apt-get update` / `apt-get install acl` block behind `command -v apt-get`
- Guard the `setfacl -k /tmp` call too — if apt-get wasn't available and setfacl was never installed, the call would fail

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdw4shRJ4FqjNvSGopbVPy)_