### PR TITLE
fix: export USER so nix run .#apply inherits it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-USER="${USER:-$(id -un)}"
+export USER="${USER:-$(id -un)}"
 
 # Support running via curl | bash: if not executing from a file, clone the repo first
 if [[ ! -f "${BASH_SOURCE[0]:-}" ]]; then


### PR DESCRIPTION
## Summary
- `install.sh:7` resolved `USER` via `USER="${USER:-$(id -un)}"` but never exported it
- In containers that don't set `$USER` at all (e.g. Claude Code web environments), this means the `nix run --accept-flake-config .#apply` subprocess at `install.sh:106` doesn't inherit `USER`
- home-manager's generated activation script runs under `set -u` and reads `$USER` directly (including a `checkStringEq USER "$USER" root` sanity check), so it crashes with `USER: unbound variable` and activation never completes — even though `install.sh` itself resolves `USER` fine via `id -un`
- Fix: `export USER="${USER:-$(id -un)}"`

## Test plan
- [x] Reproduced the failure directly: `nix run --accept-flake-config .#apply` failed with `home-manager-generation: line 54: USER: unbound variable` in an environment with no `$USER` set
- [x] Confirmed exporting `USER` before the same command resolves the issue — home-manager activation completes and creates a proper generation
- [x] `nix build .#checks.x86_64-linux.shellcheck` passes against the modified `install.sh`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vs5iKAV2CETnHw3V6rx9Ei)_